### PR TITLE
docs(projects): remove blocked link

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -30,13 +30,13 @@
         "tags": "html, css, jsp, servlets, mysql"
     },
     {
-        "name": "currency-converter",
+        "name": "Roshaen",
         "display": "Currency Convertor",
         "description": "A simple website using HTML, CSS, Javascript that converts one currency amount to other",
         "author": "Roshaen",
         "category": "website",
         "level": "basic",
-        "site": "https://roshaen.github.io/currency",
+        "site": "https://github.com/Roshaen",
         "tags": "html, css, js"
     },
     {

--- a/data/projects.json
+++ b/data/projects.json
@@ -30,16 +30,6 @@
         "tags": "html, css, jsp, servlets, mysql"
     },
     {
-        "name": "Roshaen",
-        "display": "Currency Convertor",
-        "description": "A simple website using HTML, CSS, Javascript that converts one currency amount to other",
-        "author": "Roshaen",
-        "category": "website",
-        "level": "basic",
-        "site": "https://github.com/Roshaen",
-        "tags": "html, css, js"
-    },
-    {
         "name": "eLearning",
         "display": "eLearning",
         "description": "It's a simple landing page. Made with Bootstrap 5.",

--- a/docs/WEBSITE_BASIC.md
+++ b/docs/WEBSITE_BASIC.md
@@ -1,5 +1,5 @@
 # Website - Basic
-  - [Currency Convertor](https://github.com/Roshaen) - [@Roshaen](https://github.com/Roshaen)
+  - [Currency Convertor](https://github.com/Roshaen/currency-converter) - [@Roshaen](https://github.com/Roshaen)
   - [eLearning](https://github.com/hasan-naim/eLearning) - [@hasan-naim](https://github.com/hasan-naim)
   - [Stickies](https://github.com/franciscoh017/stickies) - [@franciscoh017](https://github.com/franciscoh017)
   - [franciscoh017 Profile](https://github.com/franciscoh017/franciscoh017.github.io) - [@franciscoh017](https://github.com/franciscoh017)

--- a/docs/WEBSITE_BASIC.md
+++ b/docs/WEBSITE_BASIC.md
@@ -1,5 +1,5 @@
 # Website - Basic
-  - [Currency Convertor](https://github.com/Roshaen/currency-converter) - [@Roshaen](https://github.com/Roshaen)
+  - [Currency Convertor](https://github.com/Roshaen) - [@Roshaen](https://github.com/Roshaen)
   - [eLearning](https://github.com/hasan-naim/eLearning) - [@hasan-naim](https://github.com/hasan-naim)
   - [Stickies](https://github.com/franciscoh017/stickies) - [@franciscoh017](https://github.com/franciscoh017)
   - [franciscoh017 Profile](https://github.com/franciscoh017/franciscoh017.github.io) - [@franciscoh017](https://github.com/franciscoh017)


### PR DESCRIPTION
## Description
A link to project repository called _Currency Converter_ from https://ideashub.netlify.app/projects is invalid. Either the author has removed that repo from his profile, or for some reason, that link is not working. <br>
![image](https://user-images.githubusercontent.com/72611571/191574264-58b55977-417e-4a71-9eb2-d2d98967146a.png)
<br>
## Context
Original link - https://github.com/Roshaen/currency-converter
Fixed link - https://github.com/Roshaen/Roshaen
The new link takes you directly to the author's profile README.md because I didn't find any suitable repository to show.
## Related Issue
This PR fixes #99 
## How Has This Been Tested?
I've tested new projects page using [netlify.app](https://netlify.app/) and the testrun is on [this link](https://ideahub-test.netlify.app/projects).


