### PR TITLE
docs(ideas): add major days in history

### DIFF
--- a/data/ideas.json
+++ b/data/ideas.json
@@ -225,7 +225,7 @@
         "title": "Major Days in History",
         "description": "A web application containing major days in history including births, deaths, inventions, wars, etc. User can search for days, events or persons using an API.",
         "level": "intermediate",
-        "tags": "api-requests, web-app, search"
+        "tags": "major-days-in-history, search"
     }
 
 ]

--- a/data/ideas.json
+++ b/data/ideas.json
@@ -223,7 +223,7 @@
     },
     {
         "title": "Major Days in History",
-        "description": "A web application containing major days in history including births, deaths, inventions, wars, etc. User can search for days, events or persons using an API.",
+        "description": "A web application comprising major days in history including births, deaths, inventions, wars, etc. User can search for days, events or persons using an API.",
         "level": "intermediate",
         "tags": "major-days-in-history, search"
     }

--- a/docs/WEBSITE_BASIC.md
+++ b/docs/WEBSITE_BASIC.md
@@ -1,5 +1,4 @@
 # Website - Basic
-  - [Currency Convertor](https://github.com/Roshaen/currency-converter) - [@Roshaen](https://github.com/Roshaen)
   - [eLearning](https://github.com/hasan-naim/eLearning) - [@hasan-naim](https://github.com/hasan-naim)
   - [Stickies](https://github.com/franciscoh017/stickies) - [@franciscoh017](https://github.com/franciscoh017)
   - [franciscoh017 Profile](https://github.com/franciscoh017/franciscoh017.github.io) - [@franciscoh017](https://github.com/franciscoh017)


### PR DESCRIPTION
I added an idea to the ideas.json and it's a web application that grants the user access to days in history. A user can search by day, events, persons, etc using an API. It's a mini-wiki for history.
I hope my idea is granted access to IdeaHub. It's my first open source contribution. Thank you, maintainers.